### PR TITLE
Fix: Correctly display routes on the frontend

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2749,9 +2749,8 @@ async getDirections() {
       this.routesByTime = [];
 
       // 处理距离最短路线
-      if (routesData.shortest_distance) {
-          const baseDistanceRoute = routesData.shortest_distance;
-          
+      const baseDistanceRoute = routesData.shortest_distance_routes && routesData.shortest_distance_routes.length > 0 ? routesData.shortest_distance_routes[0] : null;
+      if (baseDistanceRoute) {
           // 创建5个距离优化的候选路线（当前只有一个真实路线，其他为演示）
           for (let i = 0; i < 5; i++) {
               // 为演示目的，添加一些随机变化
@@ -2774,9 +2773,8 @@ async getDirections() {
       }
 
       // 处理时间最短路线
-      if (routesData.fastest_travel_time) {
-          const baseTimeRoute = routesData.fastest_travel_time;
-          
+      const baseTimeRoute = routesData.fastest_travel_time_routes && routesData.fastest_travel_time_routes.length > 0 ? routesData.fastest_travel_time_routes[0] : null;
+      if (baseTimeRoute) {
           // 创建5个时间优化的候选路线
           for (let i = 0; i < 5; i++) {
               const variation = i * 0.08; // 8%的变化


### PR DESCRIPTION
The frontend was not correctly parsing the route data from the backend response, leading to routes not being displayed on the map.

This commit addresses the issue by:
- Modifying the `getDirections` method in `frontend/src/main.js` (Dashboard component) to correctly access the nested route objects from the backend response. Specifically, it now uses `routesData.shortest_distance_routes[0]` and `routesData.fastest_travel_time_routes[0]` instead of the previously incorrect keys.
- Adding null checks to handle cases where distance or time optimized routes might not be present in the response.

With these changes, the frontend should now correctly extract the route data, pass it to the map display component, and render the routes on the map as intended.